### PR TITLE
Use wx.App instead of wx.PySimpleApp to avoid deprecation warning

### DIFF
--- a/PyPose.py
+++ b/PyPose.py
@@ -407,7 +407,7 @@ class NewProjectDialog(wx.Dialog):
 
 if __name__ == "__main__":
     print "PyPose starting... "
-    app = wx.PySimpleApp()
+    app = wx.App()
     frame = editor()
     app.MainLoop()
 


### PR DESCRIPTION
Fixes #8
